### PR TITLE
Make icon set System Theme icons the default

### DIFF
--- a/theme/chrome/css/UI/navbar.css
+++ b/theme/chrome/css/UI/navbar.css
@@ -302,7 +302,7 @@ background-position: -2px -3px !important;
 }
 
 @media (-moz-platform: linux) {
-  @supports (-moz-bool-pref("silverfox.systemThemeIcons")) {
+  @supports not ((-moz-bool-pref("silverfox.disableSystemThemeIcons")) or (-moz-bool-pref("silverfox.beChromeOS")) or (-moz-bool-pref("silverfox.forceWindowsStyling"))) {
     #forward-button:not(:-moz-lwtheme),
     #back-button:not(:-moz-lwtheme),
     #reload-button:not(:-moz-lwtheme),

--- a/theme/chrome/resources/pages/flags/JS/script.js
+++ b/theme/chrome/resources/pages/flags/JS/script.js
@@ -29,7 +29,7 @@ function getPrefName(flagName) {
         'Be Chrome OS': 'silverfox.beChromeOS',
         'Enable Aero Glass': 'silverfox.hasAeroGlass',
         'Restore Old Look': 'silverfox.preferOldLook',
-        'Icons on System Theme': 'silverfox.systemThemeIcons',
+        'Standard icons on System Theme': 'silverfox.disableSystemThemeIcons',
         'Allow Homepage Images': 'silverfox.hasLocalImage',
         'Enable Profile Pictures': 'silverfox.usepfp',
         'Force Windows Styling': 'silverfox.forceWindowsStyling'

--- a/theme/chrome/resources/pages/flags/css/flags.css
+++ b/theme/chrome/resources/pages/flags/css/flags.css
@@ -100,10 +100,11 @@ red {
 
 .notAvailable[type="forceWindows"],
 .notAvailable[type="oldLook"],
-.notAvailable[type="systemThemeIcons"],
+.notAvailable[type="disableSystemThemeIcons"],
 .notAvailable[type="beChromeOS"],
-.enableSystemThemeIcons,
 .enableDisableChromeOS,
+.enableDisableForceWindows,
+.enableDisableSystemThemeIcons,
 .enableDisableAero {
     display: none;
 }
@@ -118,14 +119,10 @@ red {
     }
 }
 
-.enableDisableForceWindows {
-    display: none;
-}
-
 @media (-moz-platform: linux) {
     .enableDisableChromeOS,
     .enableDisableForceWindows,
-    .enableSystemThemeIcons {
+    .enableDisableSystemThemeIcons {
         display: block !important;
     }
 
@@ -136,30 +133,30 @@ red {
 @supports (-moz-bool-pref("silverfox.beChromeOS")) { 
     .enableDisableOld,
     .enableDisableForceWindows,
-    .enableSystemThemeIcons {
+    .enableDisableSystemThemeIcons {
         display: none !important;
     }
     
     .notAvailable[type="forceWindows"],
     .notAvailable[type="oldLook"],
-    .notAvailable[type="systemThemeIcons"] {
+    .notAvailable[type="disableSystemThemeIcons"] {
         display: block !important;
     }
 }
     
 @supports (-moz-bool-pref("silverfox.forceWindowsStyling")) {
     .enableDisableChromeOS,
-    .enableSystemThemeIcons {
+    .enableDisableSystemThemeIcons {
         display: none !important;
     }
 
     .notAvailable[type="beChromeOS"],
-    .notAvailable[type="systemThemeIcons"] {
+    .notAvailable[type="disableSystemThemeIcons"] {
         display: block !important;
     }
 }
 
-@supports (-moz-bool-pref("silverfox.systemThemeIcons")) {
+@supports (-moz-bool-pref("silverfox.disableSystemThemeIcons")) {
     .enableDisableChromeOS,
     .enableDisableForceWindows {
         display: none !important;

--- a/theme/chrome/resources/pages/flags/flags.xhtml
+++ b/theme/chrome/resources/pages/flags/flags.xhtml
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
   updateSwitchText('Be Chromium');
   updateSwitchText('Be Chrome OS');
-  updateSwitchText('Icons on System Theme');
+  updateSwitchText('Standard icons on System Theme');
   updateSwitchText('Enable Aero Glass');
   updateSwitchText('Restore Old Look');
   updateSwitchText('Allow Homepage Images');
@@ -71,16 +71,16 @@ document.addEventListener('DOMContentLoaded', function() {
     
     <div class="experimentFlag">
       <div class="experimentName">
-      <p class="flagName">Icons on System Theme</p>
+      <p class="flagName">Standard icons on System Theme</p>
       <p class="flagMention">Linux only</p>
       </div>
       <div class="experimentInfo">
-      <p class="aboutInfo">Allows System Theme to use your icon theme on the toolbar icons, as 2012 Google once intended.</p>
+      <p class="aboutInfo">Disables usage of your icon theme for the toolbar icons in System Theme.</p>
       </div>
-      <div class="enableSwitch" data-flag="Icons on System Theme">
-        <a class="enableSystemThemeIcons" href="#" onclick="toggleFlag('Icons on System Theme', 'silverfox.systemThemeIcons')">Enable</a>
+      <div class="enableSwitch" data-flag="Standard icons on System Theme">
+        <a class="enableDisableSystemThemeIcons" href="#" onclick="toggleFlag('Standard icons on System Theme', 'silverfox.disableSystemThemeIcons')">Enable</a>
         <p class="notAvailable" type="linuxTitlebars">Sorry, this flag is not available on your platform.</p>
-        <p class="notAvailable" type="systemThemeIcons">Sorry, this flag can't be combined with your existing flags.</p>
+        <p class="notAvailable" type="disableSystemThemeIcons">Sorry, this flag is not available on your platform.</p>
       </div>
     </div>
 


### PR DESCRIPTION
I've had some deliberation for a little while now, and come to the decision to flip this flag to be opt-out rather than opt-in, purely so that users of Silverfox get the 100% authentic experience out of the box instead of the 80% authentic experience that's currently available in Silverfox.  

This hasn't been pushed to main yet so that it can get any testing on non-Linux before being done, and this also renames the setting in about:config to reflect this change.  